### PR TITLE
fix: Use pthon buster as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.9-buster
 
 WORKDIR ./mlsb-platform
 LABEL maintainer "Dallas Fraser <dallas.fraser.waterloo@gmail.com>"


### PR DESCRIPTION
## Checklist

- [x] I have added the appropriate label to this PR ("bug", "feature")
- [x] I have assigned myself to this PR
- [x] I have performed a self-review of my code
- [x] I have tested my changes to the best of my abilities (not just unit tests, but integration/end-to-end tests as well)

## Issues closed

## Related issues

## Description

Prevents the need to setup pg_config
Probably closer to what fly.io production would use

## Screenshots
