### PR TITLE
fix: Address triples not being part of batting calculations

### DIFF
--- a/api/models/game.py
+++ b/api/models/game.py
@@ -284,6 +284,7 @@ class Game(DB.Model):
                 or_(
                     (Bat.classification == 's'),
                     (Bat.classification == 'ss'),
+                    (Bat.classification == 't'),
                     (Bat.classification == 'd'),
                     (Bat.classification == 'hr')
                 )
@@ -303,6 +304,7 @@ class Game(DB.Model):
                 or_(
                     (Bat.classification == 's'),
                     (Bat.classification == 'ss'),
+                    (Bat.classification == 't'),
                     (Bat.classification == 'd'),
                     (Bat.classification == 'hr')
                 )

--- a/api/queries/player.py
+++ b/api/queries/player.py
@@ -56,6 +56,7 @@ def player_summary(year=None, team_id=None, league_id=None, player_id=None):
                 'rbi': 0,
                 'bats': 0,
                 'avg': 0.000,
+                'sp': 0.000,
                 'name': player[0]
             }
         result[player[3]][player[1]] = player[2]
@@ -63,24 +64,43 @@ def player_summary(year=None, team_id=None, league_id=None, player_id=None):
     final_result = {}
     for player in result:
         # calculate the bats and average
-        result[player]['bats'] = (result[player]['s'] +
-                                  result[player]['ss'] +
-                                  result[player]['d'] +
-                                  result[player]['hr'] +
-                                  result[player]['t'] + 
-                                  result[player]['k'] +
-                                  result[player]['fo'] +
-                                  result[player]['fc'] +
-                                  result[player]['e'] +
-                                  result[player]['go']
-                                  )
+        result[player]['bats'] = (
+            result[player]['s'] +
+            result[player]['ss'] +
+            result[player]['d'] +
+            result[player]['hr'] +
+            result[player]['t'] + 
+            result[player]['k'] +
+            result[player]['fo'] +
+            result[player]['fc'] +
+            result[player]['e'] +
+            result[player]['go']
+        )
         bats = max(result[player]['bats'], 1)
-        result[player]['avg'] = round(((result[player]['s'] +
-                                        result[player]['ss'] +
-                                        result[player]['t'] +
-                                        result[player]['d'] +
-                                        result[player]['hr']) /
-                                       result[player]['bats']), 3)
+        result[player]['avg'] = round(
+            (
+                (
+                    result[player]['s'] +
+                    result[player]['ss'] +
+                    result[player]['t'] +
+                    result[player]['d'] +
+                    result[player]['hr']
+                ) / result[player]['bats']
+            ),
+            3
+        )
+        result[player]['sp'] = round(
+            (
+                (
+                    result[player]['s'] +
+                    result[player]['ss'] +
+                    result[player]['d'] * 2 +
+                    result[player]['t'] * 3 +
+                    result[player]['hr'] * 4
+                ) / result[player]['bats']
+            ),
+            3
+        )
         player_name = result[player].pop('name', None)
         final_result[player_name] = result[player]
     return final_result

--- a/api/queries/player.py
+++ b/api/queries/player.py
@@ -46,6 +46,7 @@ def player_summary(year=None, team_id=None, league_id=None, player_id=None):
                 'd': 0,
                 'hr': 0,
                 'ss': 0,
+                't': 0,
                 'k': 0,
                 'fo': 0,
                 'fc': 0,
@@ -66,6 +67,7 @@ def player_summary(year=None, team_id=None, league_id=None, player_id=None):
                                   result[player]['ss'] +
                                   result[player]['d'] +
                                   result[player]['hr'] +
+                                  result[player]['t'] + 
                                   result[player]['k'] +
                                   result[player]['fo'] +
                                   result[player]['fc'] +
@@ -75,6 +77,7 @@ def player_summary(year=None, team_id=None, league_id=None, player_id=None):
         bats = max(result[player]['bats'], 1)
         result[player]['avg'] = round(((result[player]['s'] +
                                         result[player]['ss'] +
+                                        result[player]['t'] +
                                         result[player]['d'] +
                                         result[player]['hr']) /
                                        result[player]['bats']), 3)

--- a/api/templates/website/player.html
+++ b/api/templates/website/player.html
@@ -11,6 +11,9 @@
                 <th data-cy="teamHeading" data-priority="2">
                     Team
                 </th>
+                <th data-cy="abHeading">
+                    AB
+                </th>
                 <th data-cy="sHeading">
                     S
                 </th>
@@ -20,29 +23,23 @@
                 <th data-cy="dHeading">
                     D
                 </th>
+                <th data-cy="tHeading">
+                    T
+                </th>
                 <th data-cy="hrHeading" data-priority="3">
                     HR
+                </th>
+                <th data-cy="rbiHeading">
+                    RBI
                 </th>
                 <th data-cy="kHeading">
                     K
                 </th>
-                <th data-cy="pfHeading">
-                    PF
-                </th>
-                <th data-cy="fcHeading">
-                    FC
-                </th>
-                <th data-cy="goHeading">
-                    GO
-                </th>
-                <th data-cy="abHeading">
-                    AB
-                </th>
                 <th data-cy="aveHeading">
                     AVE
                 </th>
-                <th data-cy="rbiHeading">
-                    RBI
+                <th data-cy="aveHeading">
+                    SLG
                 </th>
             </tr>
         </thead>
@@ -57,6 +54,9 @@
                             {{entry.team}}
                         </a>
                     </td>
+                    <td data-cy="abCell">
+                        {{entry.bats}}
+                    </td>
                     <td data-cy="sCell">
                         {{entry.s}}
                     </td>
@@ -66,34 +66,43 @@
                     <td data-cy="dCell">
                         {{entry.d}}
                     </td>
+                    <td data-cy="dCell">
+                        {{entry.t}}
+                    </td>
                     <td data-cy="hrCell">
                         {{entry.hr}}
-                    </td>
-                    <td data-cy="kCell">
-                        {{entry.k}}
-                    </td>
-                    <td data-cy="foCell">
-                        {{entry.fo}}
-                    </td>
-                    <td data-cy="fcCell">
-                        {{entry.fc}}
-                    </td>
-                    <td data-cy="goCell">
-                        {{entry.go}}
-                    </td>
-                    <td data-cy="abCell">
-                        {{entry.bats}}
-                    </td>
-                    <td data-cy="aveCell">
-                        {{'%0.3f'| format(entry.avg)}}
                     </td>
                     <td data-cy="rbiCell">
                         {{entry.rbi}}
                     </td>
+                    <td data-cy="kCell">
+                        {{entry.k}}
+                    </td>
+                    <td data-cy="aveCell">
+                        {{'%0.3f'| format(entry.avg)}}
+                    </td>
+                    <td data-cy="spCell">
+                        {{'%0.3f'| format(entry.sp)}}
+                    </td>
                 </tr>
-
             {% endfor %}
         </tbody>
+        <tfooter>
+            <tr>
+                <th>--</th>
+                <th>Career</th>
+                <th>{{career.bats}}</th>
+                <th>{{career.s}}</th>
+                <th>{{career.ss}}</th>
+                <th>{{career.d}}</th>
+                <th>{{career.t}}</th>
+                <th>{{career.hr}}</th>
+                <th>{{career.rbi}}</th>
+                <th>{{career.k}}</th>
+                <th>{{career.avg}}</th>
+                <th>{{career.sp}}</th>
+            </tr>
+        </tfooter>
     </table>
 {% endblock %}
 {% block script %}

--- a/api/templates/website/stats.html
+++ b/api/templates/website/stats.html
@@ -8,6 +8,9 @@
                 <th data-priority="1" data-cy="nameHeading">
                     Name
                 </th>
+                <th data-cy="abHeading">
+                    AB
+                </th>
                 <th data-priority="4" data-cy="sHeading">
                     S
                 </th>
@@ -17,29 +20,23 @@
                 <th data-cy="dHeading">
                     D
                 </th>
+                <th data-cy="dHeading">
+                    T
+                </th>
                 <th data-priority="2" data-cy="hrHeading">
                     HR
+                </th>
+                <th data-cy="rbiHeading">
+                    RBI
                 </th>
                 <th data-cy="kHeading">
                     K
                 </th>
-                <th data-cy="pfHeading">
-                    PF
-                </th>
-                <th data-cy="fcHeading">
-                    FC
-                </th>
-                <th data-cy="goHeading">
-                    GO
-                </th>
-                <th data-cy="abHeading">
-                    AB
-                </th>
                 <th data-cy="aveHeading">
                     AVE
                 </th>
-                <th data-cy="rbiHeading">
-                    RBI
+                <th data-cy="aveHeading">
+                    SLG
                 </th>
             </tr>
         </thead>
@@ -53,6 +50,9 @@
                             {{name}}
                         </a>
                     </td>
+                    <td data-cy="abCell">
+                        {{entry.bats}}
+                    </td>
                     <td data-cy="sCell">
                         {{entry.s}}
                     </td>
@@ -62,32 +62,25 @@
                     <td data-cy="dCell">
                         {{entry.d}}
                     </td>
+                    <td data-cy="dCell">
+                        {{entry.t}}
+                    </td>
                     <td data-cy="hrCell">
                         {{entry.hr}}
-                    </td>
-                    <td data-cy="kCell">
-                        {{entry.k}}
-                    </td>
-                    <td data-cy="foCell">
-                        {{entry.fo}}
-                    </td>
-                    <td data-cy="fcCell">
-                        {{entry.fc}}
-                    </td>
-                    <td data-cy="goCell">
-                        {{entry.go}}
-                    </td>
-                    <td data-cy="abCell">
-                        {{entry.bats}}
-                    </td>
-                    <td data-cy="aveCell">
-                        {{'%0.3f'| format(entry.avg)}}
                     </td>
                     <td data-cy="rbiCell">
                         {{entry.rbi}}
                     </td>
+                    <td data-cy="rbiCell">
+                        {{entry.k}}
+                    </td>
+                    <td data-cy="aveCell">
+                        {{'%0.3f'| format(entry.avg)}}
+                    </td>
+                    <td data-cy="spCell">
+                        {{'%0.3f'| format(entry.sp)}}
+                    </td>
                 </tr>
-
             {% endfor %}
         </tbody>
     </table>
@@ -97,7 +90,7 @@
 $(document).ready(ready());
 function ready(){
         $('#players_stats').DataTable({
-            "order": [[4, "desc"]],
+            "order": [[6, "desc"]],
             "responsive": true,
         });
 }

--- a/api/templates/website/team.html
+++ b/api/templates/website/team.html
@@ -248,13 +248,14 @@
 <table class="display" id="teamTable" cellspacing="0" width="100%">
     <thead>
         <th data-priority="1">Player</th>
-        <th>Ave.</th>
-        <th>SP</th>
+        <th>AB</th>
         <th>S</th>
         <th data-priority="3">SS</th>
         <th>D</th>
+        <th>T</th>
         <th data-priority="2">HR</th>
-        <th>AB</th>
+        <th>AVE</th>
+        <th>SLG</th>
     </thead>
     <tbody>
         {% for player in team.stats %}
@@ -264,13 +265,14 @@
                         {{player.name}}
                     </a>
                 </td>
-                <td>{{player.ba}}</td>
-                <td>{{player.sp}}</td>
+                <td>{{player.bats}}</td>
                 <td>{{player.s}}</td>
                 <td>{{player.ss}}</td>
                 <td>{{player.d}}</td>
+                <td>{{player.t}}</td>
                 <td>{{player.hr}}</td>
-                <td>{{player.bats}}</td>
+                <td>{{player.ba}}</td>
+                <td>{{player.sp}}</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/api/website/helpers.py
+++ b/api/website/helpers.py
@@ -18,24 +18,17 @@ def get_team(year, team_id: int) -> dict:
         p_ = player_summary(team_id=team_id)
         stats = []
         for name in p_:
-            sp = (
-                (
-                    p_[name]["s"] +
-                    p_[name]["ss"] +
-                    p_[name]["d"] * 2 +
-                    p_[name]["hr"] * 4
-                ) / p_[name]['bats']
-            )
             stats.append({
                 'id': p_[name]['id'],
                 'name': name,
                 'ss': p_[name]['ss'],
                 's': p_[name]['s'],
                 'd': p_[name]['d'],
+                't': p_[name]['t'],
                 'hr': p_[name]['hr'],
                 'bats': p_[name]['bats'],
                 'ba': "{0:.3f}".format(p_[name]['avg']),
-                'sp': "{0:.3f}".format(sp)
+                'sp': "{0:.3f}".format(p_[name]['sp']),
             })
         record = single_team(team_id)
         league_name = "No league"

--- a/api/website/team.py
+++ b/api/website/team.py
@@ -71,6 +71,23 @@ def player_page(year, player_id):
     for team in player.teams:
         years.append((team.year, team.id))
     stats = []
+    career = {
+        's': 0,
+        'd': 0,
+        't': 0,
+        'hr': 0,
+        'ss': 0,
+        'k': 0,
+        'fo': 0,
+        'fc': 0,
+        'e': 0,
+        'go': 0,
+        'id': player_id,
+        'rbi': 0,
+        'avg': 0.000,
+        'sp': 0.000,
+        'bats': 0
+    }
     for entry in years:
         player = {}
         summary = player_summary(
@@ -84,6 +101,7 @@ def player_page(year, player_id):
             player = {
                 's': 0,
                 'd': 0,
+                't': 0,
                 'hr': 0,
                 'ss': 0,
                 'k': 0,
@@ -94,17 +112,48 @@ def player_page(year, player_id):
                 'id': player_id,
                 'rbi': 0,
                 'avg': 0.000,
+                'sp': 0.000,
                 'bats': 0
             }
         player['team'] = str(Team.query.get(entry[1]))
         player['team_id'] = entry[1]
         player['year'] = entry[0]
         stats.append(player)
+        career['s'] += player['s']
+        career['ss'] += player['ss']
+        career['d'] += player['d']
+        career['t'] += player['t']
+        career['hr'] += player['hr']
+        career['k'] += player['k']
+        career['rbi'] += player['rbi']
+        career['bats'] += player['bats']
+    if career['bats'] > 0:
+        career['avg'] = round(
+            (
+                career['s'] +
+                career['ss'] +
+                career['d'] +
+                career['t'] +
+                career['hr']
+            ) / career['bats'],
+            3
+        )
+        career['sp'] = round(
+            (
+                career['s'] +
+                career['ss'] +
+                career['d'] * 2 +
+                career['t'] * 3 +
+                career['hr'] * 4
+            ) / career['bats'],
+            3
+        )
     return render_template(
         "website/player.html",
         stats=stats,
         title="Player Stats",
         name=name,
+        career=career,
         year=year,
         user_info=get_user_information()
     )


### PR DESCRIPTION
## Checklist

- [x] I have added the appropriate label to this PR ("bug", "feature")
- [x] I have assigned myself to this PR
- [x] I have performed a self-review of my code
- [x] I have tested my changes to the best of my abilities (not just unit tests, but integration/end-to-end tests as well)

## Issues closed

## Related issues

## Description

* Add triples to calculation for batting average
* standardize all stats columns and order
  * Additionally, add a footer for career stats on players page
  * Add slugging percentage to every page where display stats
  * Only show strike outs - not grounder / fly outs

## Screenshots
